### PR TITLE
Refactor utilities and improve tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ BlenderSCAD bridges the gap between [Blender](https://www.blender.org/) and the 
 
 ## Installation
 
-1. Clone the repository and install the package using `pip`:
+1. Clone the repository and install the package in editable mode:
    ```bash
-   pip install .
+   pip install -e .[dev]
    ```
 2. Launch Blender and ensure the `blenderscad` package is on the Python path.
 3. Enable the optional toolbar add-on by copying the contents of `addons` into Blender's `scripts/addons` directory.
@@ -30,6 +30,11 @@ See the [examples](examples) directory for more demonstrations.
 ## Development
 
 - Source code lives in the `src` directory and follows [PEP 8](https://peps.python.org/pep-0008/) style.
+- Format and lint the code using [black](https://black.readthedocs.io/) and [ruff](https://docs.astral.sh/ruff/):
+  ```bash
+  black .
+  ruff .
+  ```
 - Tests use [pytest](https://pytest.org/). Run them with:
   ```bash
   pytest

--- a/addons/blenderscad_toolbar.py
+++ b/addons/blenderscad_toolbar.py
@@ -36,6 +36,7 @@ import os
 # uncomment the following two lines to the path where your "blenderscad" module folder will be
 # (other than Blender's default location for modules)
 import sys
+import logging
 
 
 settings = {}
@@ -69,7 +70,9 @@ rel = [
 ]
 for mo in rel:
     if mo in sys.modules:
-        print("reloading: " + mo + " -> " + sys.modules[mo].__file__)
+        logging.getLogger(__name__).info(
+            "reloading: %s -> %s", mo, sys.modules[mo].__file__
+        )
         importlib.reload(sys.modules[mo])
 ########################
 
@@ -372,7 +375,7 @@ class VIEW3D_OT_blenderscad_debug(bpy.types.Operator):
 
     def execute(self, context):
         o = context.object
-        if bpy.context.active_object.mode is not "OBJECT":
+        if bpy.context.active_object.mode != "OBJECT":
             bpy.ops.object.mode_set(mode="OBJECT")
         o.show_wire = False if o.show_wire else True
         o.show_all_edges = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,19 @@ license = {file = "LICENSE.md"}
 [project.urls]
 Homepage = "https://github.com/miguelitoelgrande/BlenderSCAD"
 
+[project.optional-dependencies]
+dev = ["black", "ruff"]
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.black]
+line-length = 88
+target-version = ["py39"]
+
+[tool.ruff]
+line-length = 88
+select = ["E", "F", "I"]

--- a/src/blenderscad/__init__.py
+++ b/src/blenderscad/__init__.py
@@ -43,7 +43,7 @@ def main():
     # $fn - number of fragments  | override of $fa/$fs , default = 0 , example: 36-> every 10 degrees
     fn = 0
     if bpy.context.active_object is not None:
-        if bpy.context.active_object.mode is not "OBJECT":
+        if bpy.context.active_object.mode != "OBJECT":
             bpy.ops.object.mode_set(mode="OBJECT")
 
 

--- a/src/blenderscad/impexp.py
+++ b/src/blenderscad/impexp.py
@@ -5,7 +5,10 @@
 #
 
 import bpy
+import logging
 import blenderscad
+
+logger = logging.getLogger(__name__)
 
 # from blenderscad import *  # contains blenderscad core, primitives, math and colors
 
@@ -28,7 +31,7 @@ def import_stl(file, layer="", convexity=10):
 
 # helper to fill imported dxf -> before linear extrude?
 def fill_object(o):
-    if bpy.context.active_object.mode is not "EDIT":
+    if bpy.context.active_object.mode != "EDIT":
         bpy.ops.object.mode_set(mode="EDIT")
     for el in o.data.vertices:
         el.select = True
@@ -50,7 +53,7 @@ def import_dxf(file, layer="", convexity=10, fill=True):
 
     io_import_scene_dxf.theCodec = "ascii"
     sections = io_import_scene_dxf.readDxfFile(file)
-    print("Building geometry")
+    logger.info("Building geometry")
     io_import_scene_dxf.buildGeometry(sections["ENTITIES"].data)
     o = bpy.context.scene.objects.active
     if fill is True:
@@ -160,7 +163,7 @@ def surface(file, center=False, convexity=1):
             data.append(row)
             rows += 1
     ins.close()
-    print("importing surface ", file, ": rows=", rows, " cols=", cols)
+    logger.info("importing surface %s: rows=%s cols=%s", file, rows, cols)
     ox = -(cols - 1) / 2.0 if center else 0
     oy = -(rows - 1) / 2.0 if center else 0
     #

--- a/src/blenderscad/math.py
+++ b/src/blenderscad/math.py
@@ -19,6 +19,28 @@ true = True
 false = False
 pi = math.pi  # 3.141592
 
+__all__ = [
+    "true",
+    "false",
+    "pi",
+    "sin",
+    "cos",
+    "tan",
+    "acos",
+    "asin",
+    "atan",
+    "atan2",
+    "sign",
+    "rands",
+    "lookup",
+    "ceil",
+    "exp",
+    "floor",
+    "ln",
+    "log",
+    "sqrt",
+]
+
 
 def sin(deg):
     return math.sin(math.radians(deg))
@@ -32,20 +54,20 @@ def tan(deg):
     return math.tan(math.radians(deg))
 
 
-def acos(deg):
-    return math.acos(math.radians(deg))
+def acos(x):
+    return math.degrees(math.acos(x))
 
 
-def asin(deg):
-    return math.asin(math.radians(deg))
+def asin(x):
+    return math.degrees(math.asin(x))
 
 
-def atan(deg):
-    return math.atan(math.radians(deg))
+def atan(x):
+    return math.degrees(math.atan(x))
 
 
-def atan2(deg):
-    return math.atan2(math.radians(deg))
+def atan2(y, x):
+    return math.degrees(math.atan2(y, x))
 
 
 def sign(x):

--- a/src/blenderscad/primitives.py
+++ b/src/blenderscad/primitives.py
@@ -4,12 +4,13 @@
 ## by Michael Mlivoncic, 2013
 #
 import bpy
-
-# import bpy_types
+import logging
 
 from mathutils import Vector
 
 import blenderscad  # for "global" variables fn, defColor,...
+
+logger = logging.getLogger(__name__)
 
 # from blenderscad.math import *  # true, false required...
 
@@ -222,7 +223,7 @@ def polygon(points, paths=[], fill=True):
     bpy.context.scene.objects.active = o
     o.select = True
     # Note: switching mode would fail before mesh is defined and object selected...
-    if bpy.context.active_object.mode is not "EDIT":
+    if bpy.context.active_object.mode != "EDIT":
         bpy.ops.object.mode_set(mode="EDIT")
     # 	for el in o.data.vertices: el.select = True
     # 	for el in o.data.edges: el.select = True
@@ -280,7 +281,7 @@ def square(size=(1.0, 1.0), center=False, fill=False):
 # DEPRECATED: polyhedron(triangles=[]) will be removed in future releases. Use polyhedron(faces=[]) instead
 def polyhedron(points, faces=[], triangles=[], fill=False):
     if len(triangles) > 0 and len(faces) == 0:
-        print(
+        logger.warning(
             "DEPRECATED: polyhedron(triangles=[]) will be removed in future releases. Use polyhedron(faces=[]) instead"
         )
         faces = triangles
@@ -306,7 +307,7 @@ def polyhedron(points, faces=[], triangles=[], fill=False):
     bpy.context.scene.objects.active = o
     o.select = True
     # Note: switching mode would fail before mesh is defined and object selected...
-    if bpy.context.active_object.mode is not "EDIT":
+    if bpy.context.active_object.mode != "EDIT":
         bpy.ops.object.mode_set(mode="EDIT")
     for el in o.data.vertices:
         el.select = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "src"))

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -1,10 +1,11 @@
 import sys
 import types
 
-sys.modules.setdefault("bpy", types.ModuleType("bpy"))
+import pytest
 
-import blenderscad.math as bmath
-import blenderscad.colors as colors
+sys.modules.setdefault("bpy", types.ModuleType("bpy"))
+import blenderscad.math as bmath  # noqa: E402,I001
+import blenderscad.colors as colors  # noqa: E402,I001
 
 
 def test_rands_repeatable():
@@ -18,3 +19,10 @@ def test_lookup_exact_match():
 
 def test_color_constant():
     assert colors.red == (1.0, 0.0, 0.0, 0)
+
+
+def test_inverse_trig_functions():
+    assert bmath.acos(1) == 0
+    assert bmath.asin(0) == 0
+    assert bmath.atan(1) == pytest.approx(45)
+    assert bmath.atan2(1, 1) == pytest.approx(45)


### PR DESCRIPTION
## Summary
- replace deprecated Blender string comparisons and scene unlink API
- reimplement inverse trig helpers to use degrees and expose module exports
- switch debug prints to logging and document dev workflow

## Testing
- `black addons/blenderscad_toolbar.py src/blenderscad/__init__.py src/blenderscad/core.py src/blenderscad/impexp.py src/blenderscad/math.py src/blenderscad/primitives.py tests/test_math.py tests/conftest.py`
- `ruff check addons/blenderscad_toolbar.py src/blenderscad/__init__.py src/blenderscad/core.py src/blenderscad/impexp.py src/blenderscad/math.py src/blenderscad/primitives.py tests/test_math.py tests/conftest.py` *(fails: line length and style issues across modules)*
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae897bda408332b5825e490a7ce3a8